### PR TITLE
feat(macros): add utility macros implement!, example! and run!

### DIFF
--- a/examples/day_with_macros.rs
+++ b/examples/day_with_macros.rs
@@ -1,0 +1,21 @@
+use itertools::Itertools;
+use aoc::solution::SolutionError;
+
+aoc::implement! {
+    name: Day00;
+    title: "addition or product";
+    day: 0;
+    input : "12345".to_owned();
+    parse   -> Vec<u32> : |input: &str| input.chars().map(|c| c.to_digit(10).ok_or(SolutionError::ParseError)).collect();
+    part_1  -> u32      : |input: &Self::Input| input.iter().sum1();
+    part_2  -> u32      : |input: &Self::Input| input.iter().product1();
+}
+
+aoc::run!(Day00);
+
+
+aoc::example! {
+    [Day00]
+    example: "1234" => Some(1+2+3+4) => Some(1*2*3*4)
+    bigger: "123456789" => Some(1+2+3+4+5+6+7+8+9) => Some(1*2*3*4*5*6*7*8*9)
+}


### PR DESCRIPTION
## Description

add `implement!` macro to hide boilerplate around `implement Solution for DayXX`
add `example!` to hide boilerplate around `#[cfg(tests] mod tests {...}`
add `run!` to hide boilerplate around `fn main() { aoc::solution!(DayXX);}`

## Context

I wanted to update my library a little and add more tools to reduce code duplication. Each day I was copying the previous day's solution and removing the implementation details.

I made these macros to make that chore faster. 

I made the `implement!` mostly out of curiosity. I don't think it's the best idea though, at least in its current form.
Usage will tell.